### PR TITLE
don’t attempt to re-download punkt tokenizer

### DIFF
--- a/src/udar/sentence.py
+++ b/src/udar/sentence.py
@@ -106,7 +106,7 @@ def get_tokenizer(use_pexpect=True) -> Tokenizer:
             raise ModuleNotFoundError('Neither hfst or nltk are installed. '
                                       'One of them must be installed for '
                                       'tokenization.') from e
-        except LookupError as e: # -*- coding: utf-8 -*-
+        except LookupError as e:
             # punkt not found
             try:
                 # attempt to download punkt

--- a/src/udar/sentence.py
+++ b/src/udar/sentence.py
@@ -101,14 +101,19 @@ def get_tokenizer(use_pexpect=True) -> Tokenizer:
     else:  # TODO use stanza instead of nltk?
         try:
             import nltk  # type: ignore
-            assert nltk.download('punkt')
+            nltk.data.find('tokenizers/punkt')
         except ModuleNotFoundError as e:
             raise ModuleNotFoundError('Neither hfst or nltk are installed. '
                                       'One of them must be installed for '
                                       'tokenization.') from e
-        except AssertionError as e:
-            raise AssertionError("Cannot download nltk's `punkt` model. "
-                                 'Connect to the internet & try again.') from e
+        except LookupError as e: # -*- coding: utf-8 -*-
+            # punkt not found
+            try:
+                # attempt to download punkt
+                assert nltk.download('punkt')
+            except AssertionError as e:
+                raise AssertionError("Cannot download nltk's `punkt` model. "
+                                     'Connect to the internet & try again.') from e
         else:
             warn('hfst-tokenize not found. Using nltk.word_tokenize....',
                  ImportWarning, stacklevel=2)


### PR DESCRIPTION
Previously an attempt was made to redownload `punkt` with each request for the in-use tokenizer, causing nltk to emit warnings about `punkt` already being downloaded.  This change attempts to find `punkt` and if not present to _then_ download it.